### PR TITLE
feat(multiple): Split resource into multiple schematics 

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm test)",
+      "mcp__Linear__get_issue",
+      "Bash(npm run build:*)"
+    ],
+    "deny": [],
+    "ask": []
+  },
+  "enabledMcpjsonServers": [
+    "Sentry",
+    "Linear",
+    "Notion",
+    "Figma"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@ schematics/
 dist
 
 src/lib/**/*.js
-src/lib/**/*.d.ts
-!src/lib/resource/*.d.ts
 !src/lib/**/files/**/*
 !src/lib/**/workspace/**/*
 src/utils/**/*.js

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "Sentry": {
+      "type": "sse",
+      "url": "https://mcp.sentry.dev/sse"
+    },
+    "Linear": {
+      "type": "sse",
+      "url": "https://mcp.linear.app/sse"
+    },
+    "Notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "Figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
+    }
+  }
+}

--- a/src/collection.json
+++ b/src/collection.json
@@ -117,6 +117,30 @@
       "description": "Create a Nest resource.",
       "schema": "./lib/resource/schema.json",
       "aliases": ["res"]
+    },
+    "api-service": {
+      "factory": "./lib/api-service/api-service.factory#main",
+      "description": "Create a REST API service.",
+      "schema": "./lib/api-service/schema.json",
+      "aliases": ["api-s"]
+    },
+    "api-controller": {
+      "factory": "./lib/api-controller/api-controller.factory#main",
+      "description": "Create a REST API controller.",
+      "schema": "./lib/api-controller/schema.json",
+      "aliases": ["api-c"]
+    },
+    "api-dtos": {
+      "factory": "./lib/api-dtos/api-dtos.factory#main",
+      "description": "Create REST API DTOs.",
+      "schema": "./lib/api-dtos/schema.json",
+      "aliases": ["api-dto"]
+    },
+    "api-e2e-tests": {
+      "factory": "./lib/api-e2e-tests/api-e2e-tests.factory#main",
+      "description": "Create REST API E2E tests.",
+      "schema": "./lib/api-e2e-tests/schema.json",
+      "aliases": ["api-e2e"]
     }
   }
 }

--- a/src/lib/api-controller/api-controller.factory.test.ts
+++ b/src/lib/api-controller/api-controller.factory.test.ts
@@ -1,0 +1,138 @@
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { ApiControllerOptions } from './api-controller.schema';
+
+describe('API Controller Factory', () => {
+  const runner: SchematicTestRunner = new SchematicTestRunner(
+    '.',
+    path.join(process.cwd(), 'src/collection.json'),
+  );
+
+  describe('with CRUD enabled', () => {
+    it('should generate controller with CRUD endpoints', async () => {
+      const options: ApiControllerOptions = {
+        name: 'users',
+        skipImport: true,
+        flat: true,
+        crud: true,
+        isSwaggerInstalled: true,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-controller', options)
+        .toPromise();
+      const files: string[] = tree.files;
+
+      expect(
+        files.find((filename) => filename === '/users.controller.ts'),
+      ).toBeDefined();
+
+      const content = tree.readContent('/users.controller.ts');
+      expect(content).toContain('public async create');
+      expect(content).toContain('public async findAll');
+      expect(content).toContain('public async findOne');
+      expect(content).toContain('public async update');
+      expect(content).toContain('public async remove');
+      expect(content).toContain('@Post()');
+      expect(content).toContain('@Get()');
+      expect(content).toContain('@Get(\':id\')');
+      expect(content).toContain('@Patch(\':id\')');
+      expect(content).toContain('@Delete(\':id\')');
+    });
+
+    it('should include Swagger decorators when isSwaggerInstalled is true', async () => {
+      const options: ApiControllerOptions = {
+        name: 'users',
+        skipImport: true,
+        flat: true,
+        crud: true,
+        isSwaggerInstalled: true,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-controller', options)
+        .toPromise();
+
+      const content = tree.readContent('/users.controller.ts');
+      expect(content).toContain('@ApiOperation');
+      expect(content).toContain('@ApiCreatedResponse');
+      expect(content).toContain('@ApiOkResponse');
+      expect(content).toContain('@ApiNotFoundResponse');
+      expect(content).toContain('from \'@nestjs/swagger\'');
+    });
+
+    it('should not include Swagger decorators when isSwaggerInstalled is false', async () => {
+      const options: ApiControllerOptions = {
+        name: 'users',
+        skipImport: true,
+        flat: true,
+        crud: true,
+        isSwaggerInstalled: false,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-controller', options)
+        .toPromise();
+
+      const content = tree.readContent('/users.controller.ts');
+      expect(content).not.toContain('@ApiOperation');
+      expect(content).not.toContain('from \'@nestjs/swagger\'');
+    });
+  });
+
+  describe('with CRUD disabled', () => {
+    it('should generate controller without CRUD endpoints', async () => {
+      const options: ApiControllerOptions = {
+        name: 'users',
+        skipImport: true,
+        flat: true,
+        crud: false,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-controller', options)
+        .toPromise();
+
+      const content = tree.readContent('/users.controller.ts');
+      expect(content).toContain('export class UsersController');
+      expect(content).not.toContain('public async create');
+      expect(content).not.toContain('public async findAll');
+      expect(content).not.toContain('@Post()');
+    });
+  });
+
+  describe('naming', () => {
+    it('should handle plural names correctly', async () => {
+      const options: ApiControllerOptions = {
+        name: 'users',
+        skipImport: true,
+        flat: true,
+        crud: true,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-controller', options)
+        .toPromise();
+
+      const content = tree.readContent('/users.controller.ts');
+      expect(content).toContain('export class UsersController');
+      expect(content).toContain('UserDto');
+      expect(content).toContain('CreateUserDto');
+      expect(content).toContain('UpdateUserDto');
+    });
+
+    it('should normalize names to kebab-case', async () => {
+      const options: ApiControllerOptions = {
+        name: 'userProfiles',
+        skipImport: true,
+        flat: true,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-controller', options)
+        .toPromise();
+      const files: string[] = tree.files;
+
+      expect(
+        files.find((filename) => filename === '/user-profiles.controller.ts'),
+      ).toBeDefined();
+    });
+  });
+});

--- a/src/lib/api-controller/api-controller.factory.ts
+++ b/src/lib/api-controller/api-controller.factory.ts
@@ -1,0 +1,102 @@
+import { join, Path, strings } from '@angular-devkit/core';
+import { classify } from '@angular-devkit/core/src/utils/strings';
+import {
+  apply,
+  branchAndMerge,
+  chain,
+  mergeWith,
+  move,
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  template,
+  Tree,
+  url,
+} from '@angular-devkit/schematics';
+import * as pluralize from 'pluralize';
+import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
+import {
+  DeclarationOptions,
+  ModuleDeclarator,
+} from '../../utils/module.declarator';
+import { ModuleFinder } from '../../utils/module.finder';
+import { Location, NameParser } from '../../utils/name.parser';
+import { mergeSourceRoot } from '../../utils/source-root.helpers';
+import { ApiControllerOptions } from './api-controller.schema';
+
+export function main(options: ApiControllerOptions): Rule {
+  options = transform(options);
+  return (tree: Tree, context: SchematicContext) => {
+    return branchAndMerge(
+      chain([
+        mergeSourceRoot(options),
+        addDeclarationToModule(options),
+        mergeWith(generate(options)),
+      ]),
+    )(tree, context);
+  };
+}
+
+function transform(source: ApiControllerOptions): ApiControllerOptions {
+  const target: ApiControllerOptions = Object.assign({}, source);
+  target.metadata = 'controllers';
+
+  if (!target.name) {
+    throw new SchematicsException('Option (name) is required.');
+  }
+  const location: Location = new NameParser().parse(target);
+  target.name = normalizeToKebabOrSnakeCase(location.name);
+  target.path = normalizeToKebabOrSnakeCase(location.path);
+  target.language = target.language !== undefined ? target.language : 'ts';
+
+  target.path = target.flat
+    ? target.path
+    : join(target.path as Path, target.name);
+
+  target.isSwaggerInstalled = target.isSwaggerInstalled ?? false;
+
+  return target;
+}
+
+function generate(options: ApiControllerOptions) {
+  return (context: SchematicContext) =>
+    apply(url(join('./files' as Path, options.language)), [
+      template({
+        ...strings,
+        ...options,
+        lowercased: (name: string) => {
+          const classifiedName = classify(name);
+          return (
+            classifiedName.charAt(0).toLowerCase() + classifiedName.slice(1)
+          );
+        },
+        singular: (name: string) => pluralize.singular(name),
+      }),
+      move(options.path),
+    ])(context);
+}
+
+function addDeclarationToModule(options: ApiControllerOptions): Rule {
+  return (tree: Tree) => {
+    if (options.skipImport !== undefined && options.skipImport) {
+      return tree;
+    }
+    options.module = new ModuleFinder(tree).find({
+      name: options.name,
+      path: options.path as Path,
+    });
+    if (!options.module) {
+      return tree;
+    }
+    const content = tree.read(options.module).toString();
+    const declarator: ModuleDeclarator = new ModuleDeclarator();
+    tree.overwrite(
+      options.module,
+      declarator.declare(content, {
+        ...options,
+        type: 'controller',
+      } as DeclarationOptions),
+    );
+    return tree;
+  };
+}

--- a/src/lib/api-controller/api-controller.schema.d.ts
+++ b/src/lib/api-controller/api-controller.schema.d.ts
@@ -1,0 +1,44 @@
+import { Path } from '@angular-devkit/core';
+
+export interface ApiControllerOptions {
+  /**
+   * The name of the controller.
+   */
+  name: string;
+  /**
+   * The path to create the controller.
+   */
+  path?: string | Path;
+  /**
+   * The source root path
+   */
+  sourceRoot?: string;
+  /**
+   * Application language.
+   */
+  language?: string;
+  /**
+   * The path to insert the module declaration.
+   */
+  module?: Path;
+  /**
+   * Directive to insert declaration in module.
+   */
+  skipImport?: boolean;
+  /**
+   * Metadata name affected by declaration insertion.
+   */
+  metadata?: string;
+  /**
+   * When true, CRUD entry points are generated.
+   */
+  crud?: boolean;
+  /**
+   * Flag to indicate if a directory is created.
+   */
+  flat?: boolean;
+  /**
+   * When true, "@nestjs/swagger" dependency is installed in the project.
+   */
+  isSwaggerInstalled?: boolean;
+}

--- a/src/lib/api-controller/files/ts/__name__.controller.ts
+++ b/src/lib/api-controller/files/ts/__name__.controller.ts
@@ -1,0 +1,67 @@
+<% if (crud) { %>import { Get, Post, Body, Patch, Param, Delete, Req } from '@nestjs/common';<% if (isSwaggerInstalled) { %>
+import {
+  ApiBadRequestResponse,
+  ApiCreatedResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+} from '@nestjs/swagger';<% } %>
+import { RequestWithBannerUser } from '@vori/nest/libs/auth/types';
+import { ApiEndpoint } from '@vori/nest/libs/decorators';
+import { FindOneParams } from '@vori/nest/params/FindOneParams';<% } else { %>import { Controller } from '@nestjs/common';<% } %>
+import { <%= classify(name) %>Service } from './<%= name %>.service';<% if (crud) { %>
+import { <%= singular(classify(name)) %>Dto, Create<%= singular(classify(name)) %>Dto, Update<%= singular(classify(name)) %>Dto } from './dto/<%= singular(name) %>.dto';<% } %>
+
+// TODO Add tags to group endpoints in Swagger UI
+@ApiEndpoint({ prefix: '<%= dasherize(name) %>', tags: [] })
+export class <%= classify(name) %>Controller {
+  constructor(private readonly <%= lowercased(name) %>Service: <%= classify(name) %>Service) {}<% if (crud) { %>
+<% if (isSwaggerInstalled) { %>
+  @ApiOperation({ operationId: 'create<%= singular(classify(name)) %>' })
+  @ApiCreatedResponse({ type: <%= singular(classify(name)) %>Dto })
+  @ApiBadRequestResponse()<% } %>
+  @Post()
+  public async create(
+    @Req() request: RequestWithBannerUser,
+    @Body() create<%= singular(classify(name)) %>Dto: Create<%= singular(classify(name)) %>Dto
+  ): Promise<<%= singular(classify(name)) %>Dto> {
+    const <%= singular(camelize(name)) %> = await this.<%= lowercased(name) %>Service.create({bannerID: request.user.bannerID, dto: create<%= singular(classify(name)) %>Dto});
+    return new <%= singular(classify(name)) %>Dto(<%= singular(camelize(name)) %>);
+  }
+<% if (isSwaggerInstalled) { %>
+  @ApiOperation({ operationId: 'list<%= singular(classify(name)) %>' })
+  @ApiOkResponse({ type: <%= singular(classify(name)) %>Dto, isArray: true })<% } %>
+  @Get()
+  public async findAll(@Req() request: RequestWithBannerUser): Promise<<%= singular(classify(name)) %>Dto[]> {
+    const <%= camelize(name) %> = await this.<%= lowercased(name) %>Service.findAll({bannerID: request.user.bannerID});
+    return <%= camelize(name) %>.map(<%= singular(camelize(name)) %> => new <%= singular(classify(name)) %>Dto(<%= singular(camelize(name)) %>));
+  }
+<% if (isSwaggerInstalled) { %>
+  @ApiOperation({ operationId: 'get<%= singular(classify(name)) %>' })
+  @ApiNotFoundResponse()
+  @ApiOkResponse({ type: <%= singular(classify(name)) %>Dto })<% } %>
+  @Get(':id')
+  public async findOne(@Req() request: RequestWithBannerUser, @Param() params: FindOneParams) {
+    const <%= singular(camelize(name)) %> = await this.<%= lowercased(name) %>Service.findOne({bannerID: request.user.bannerID, id: params.id});
+    return new <%= singular(classify(name)) %>Dto(<%= singular(camelize(name)) %>);
+  }
+<% if (isSwaggerInstalled) { %>
+  @ApiOperation({ operationId: 'update<%= singular(classify(name)) %>' })
+  @ApiBadRequestResponse()
+  @ApiNotFoundResponse()
+  @ApiOkResponse({ type: <%= singular(classify(name)) %>Dto })<% } %>
+  @Patch(':id')
+  public async update(@Req() request: RequestWithBannerUser, @Param() params: FindOneParams, @Body() update<%= singular(classify(name)) %>Dto: Update<%= singular(classify(name)) %>Dto) {
+    const <%= singular(camelize(name)) %> = await this.<%= lowercased(name) %>Service.update({bannerID: request.user.bannerID, id: params.id, dto: update<%= singular(classify(name)) %>Dto});
+    return new <%= singular(classify(name)) %>Dto(<%= singular(camelize(name)) %>);
+  }
+<% if (isSwaggerInstalled) { %>
+  @ApiOperation({ operationId: 'delete<%= singular(classify(name)) %>' })
+  @ApiNotFoundResponse()
+  @ApiNoContentResponse()<% } %>
+  @Delete(':id')
+  public async remove(@Req() request: RequestWithBannerUser, @Param() params: FindOneParams): Promise<void> {
+    await this.<%= lowercased(name) %>Service.remove({bannerID: request.user.bannerID, id: params.id});
+  }<% } %>
+}

--- a/src/lib/api-controller/schema.json
+++ b/src/lib/api-controller/schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "SchematicsNestApiController",
+  "title": "Nest API Controller Options Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the controller.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "The path to create the controller.",
+      "visible": false
+    },
+    "sourceRoot": {
+      "type": "string",
+      "description": "Nest controller source root."
+    },
+    "language": {
+      "type": "string",
+      "description": "Nest controller language."
+    },
+    "flat": {
+      "type": "boolean",
+      "default": false,
+      "description": "Flag to indicate if a directory is created."
+    },
+    "skipImport": {
+      "type": "boolean",
+      "default": false,
+      "description": "Flag to skip the module import."
+    },
+    "module": {
+      "type": "string",
+      "description": "The path to insert the controller declaration."
+    },
+    "crud": {
+      "type": "boolean",
+      "default": true,
+      "description": "When true, CRUD entry points are generated."
+    },
+    "isSwaggerInstalled": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, uses @nestjs/swagger decorators."
+    }
+  },
+  "required": ["name"]
+}

--- a/src/lib/api-dtos/api-dtos.factory.test.ts
+++ b/src/lib/api-dtos/api-dtos.factory.test.ts
@@ -1,0 +1,140 @@
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { ApiDtosOptions } from './api-dtos.schema';
+
+describe('API DTOs Factory', () => {
+  const runner: SchematicTestRunner = new SchematicTestRunner(
+    '.',
+    path.join(process.cwd(), 'src/collection.json'),
+  );
+
+  it('should generate DTO files', async () => {
+    const options: ApiDtosOptions = {
+      name: 'users',
+      flat: true,
+    };
+    const tree: UnitTestTree = await runner
+      .runSchematicAsync('api-dtos', options)
+      .toPromise();
+    const files: string[] = tree.files;
+
+    expect(
+      files.find((filename) => filename === '/dto/user.dto.ts'),
+    ).toBeDefined();
+  });
+
+  it('should generate DTO with correct class names', async () => {
+    const options: ApiDtosOptions = {
+      name: 'users',
+      flat: true,
+    };
+    const tree: UnitTestTree = await runner
+      .runSchematicAsync('api-dtos', options)
+      .toPromise();
+
+    const content = tree.readContent('/dto/user.dto.ts');
+    expect(content).toContain('export class UserDto');
+    expect(content).toContain('export class CreateUserDto');
+    expect(content).toContain('export class UpdateUserDto');
+  });
+
+  it('should use @nestjs/swagger when isSwaggerInstalled is true', async () => {
+    const options: ApiDtosOptions = {
+      name: 'users',
+      flat: true,
+      isSwaggerInstalled: true,
+    };
+    const tree: UnitTestTree = await runner
+      .runSchematicAsync('api-dtos', options)
+      .toPromise();
+
+    const content = tree.readContent('/dto/user.dto.ts');
+    expect(content).toContain('from \'@nestjs/swagger\'');
+  });
+
+  it('should use @nestjs/mapped-types when isSwaggerInstalled is false', async () => {
+    const options: ApiDtosOptions = {
+      name: 'users',
+      flat: true,
+      isSwaggerInstalled: false,
+    };
+    const tree: UnitTestTree = await runner
+      .runSchematicAsync('api-dtos', options)
+      .toPromise();
+
+    const content = tree.readContent('/dto/user.dto.ts');
+    expect(content).toContain('from \'@nestjs/mapped-types\'');
+  });
+
+  describe('spec file generation', () => {
+    it('should generate spec file when spec is true', async () => {
+      const options: ApiDtosOptions = {
+        name: 'users',
+        flat: true,
+        spec: true,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-dtos', options)
+        .toPromise();
+      const files: string[] = tree.files;
+
+      expect(
+        files.find((filename) => filename === '/dto/user.dto.spec.ts'),
+      ).toBeDefined();
+    });
+
+    it('should not generate spec file when spec is false', async () => {
+      const options: ApiDtosOptions = {
+        name: 'users',
+        flat: true,
+        spec: false,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-dtos', options)
+        .toPromise();
+      const files: string[] = tree.files;
+
+      expect(
+        files.find((filename) => filename === '/dto/user.dto.spec.ts'),
+      ).toBeUndefined();
+    });
+
+    it('should generate spec file with custom suffix', async () => {
+      const options: ApiDtosOptions = {
+        name: 'users',
+        flat: true,
+        spec: true,
+        specFileSuffix: 'test',
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-dtos', options)
+        .toPromise();
+      const files: string[] = tree.files;
+
+      expect(
+        files.find((filename) => filename === '/dto/user.dto.spec.ts'),
+      ).toBeUndefined();
+      expect(
+        files.find((filename) => filename === '/dto/user.dto.test.ts'),
+      ).toBeDefined();
+    });
+  });
+
+  it('should normalize names to kebab-case', async () => {
+    const options: ApiDtosOptions = {
+      name: 'userProfiles',
+      flat: true,
+    };
+    const tree: UnitTestTree = await runner
+      .runSchematicAsync('api-dtos', options)
+      .toPromise();
+    const files: string[] = tree.files;
+
+    expect(
+      files.find((filename) => filename === '/dto/user-profile.dto.ts'),
+    ).toBeDefined();
+  });
+});

--- a/src/lib/api-dtos/api-dtos.factory.ts
+++ b/src/lib/api-dtos/api-dtos.factory.ts
@@ -1,0 +1,78 @@
+import { join, Path, strings } from '@angular-devkit/core';
+import { classify } from '@angular-devkit/core/src/utils/strings';
+import {
+  apply,
+  branchAndMerge,
+  chain,
+  filter,
+  mergeWith,
+  move,
+  noop,
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  template,
+  Tree,
+  url,
+} from '@angular-devkit/schematics';
+import * as pluralize from 'pluralize';
+import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
+import { Location, NameParser } from '../../utils/name.parser';
+import { mergeSourceRoot } from '../../utils/source-root.helpers';
+import { ApiDtosOptions } from './api-dtos.schema';
+
+export function main(options: ApiDtosOptions): Rule {
+  options = transform(options);
+  return (tree: Tree, context: SchematicContext) => {
+    return branchAndMerge(
+      chain([mergeSourceRoot(options), mergeWith(generate(options))]),
+    )(tree, context);
+  };
+}
+
+function transform(source: ApiDtosOptions): ApiDtosOptions {
+  const target: ApiDtosOptions = Object.assign({}, source);
+
+  if (!target.name) {
+    throw new SchematicsException('Option (name) is required.');
+  }
+  const location: Location = new NameParser().parse(target);
+  target.name = normalizeToKebabOrSnakeCase(location.name);
+  target.path = normalizeToKebabOrSnakeCase(location.path);
+  target.language = target.language !== undefined ? target.language : 'ts';
+  target.specFileSuffix = normalizeToKebabOrSnakeCase(
+    source.specFileSuffix || 'spec',
+  );
+
+  target.path = target.flat
+    ? target.path
+    : join(target.path as Path, target.name);
+
+  target.isSwaggerInstalled = target.isSwaggerInstalled ?? false;
+
+  return target;
+}
+
+function generate(options: ApiDtosOptions) {
+  return (context: SchematicContext) =>
+    apply(url(join('./files' as Path, options.language)), [
+      options.spec
+        ? noop()
+        : filter((path) => {
+            const suffix = `.__specFileSuffix__.ts`;
+            return !path.endsWith(suffix);
+          }),
+      template({
+        ...strings,
+        ...options,
+        lowercased: (name: string) => {
+          const classifiedName = classify(name);
+          return (
+            classifiedName.charAt(0).toLowerCase() + classifiedName.slice(1)
+          );
+        },
+        singular: (name: string) => pluralize.singular(name),
+      }),
+      move(options.path),
+    ])(context);
+}

--- a/src/lib/api-dtos/api-dtos.schema.d.ts
+++ b/src/lib/api-dtos/api-dtos.schema.d.ts
@@ -1,0 +1,37 @@
+import { Path } from '@angular-devkit/core';
+
+export interface ApiDtosOptions {
+  /**
+   * The name of the resource.
+   */
+  name: string;
+  /**
+   * The path to create the DTOs.
+   */
+  path?: string | Path;
+  /**
+   * The source root path
+   */
+  sourceRoot?: string;
+  /**
+   * Application language.
+   */
+  language?: string;
+  /**
+   * Specifies if spec files are generated.
+   */
+  spec?: boolean;
+  /**
+   * Specifies the file suffix of spec files.
+   * @default "spec"
+   */
+  specFileSuffix?: string;
+  /**
+   * Flag to indicate if a directory is created.
+   */
+  flat?: boolean;
+  /**
+   * When true, "@nestjs/swagger" dependency is installed in the project.
+   */
+  isSwaggerInstalled?: boolean;
+}

--- a/src/lib/api-dtos/files/ts/dto/__name@singular__.dto.__specFileSuffix__.ts
+++ b/src/lib/api-dtos/files/ts/dto/__name@singular__.dto.__specFileSuffix__.ts
@@ -1,0 +1,30 @@
+import { faker } from '@faker-js/faker';
+import { instanceToPlain } from 'class-transformer';
+
+import { getDataSource } from '@vori/providers/database';
+
+import { makeDatabaseID } from '@vori/utils/VoriRandom';
+
+import { make<%= singular(classify(name)) %> } from '../fakers/<%= singular(name) %>.faker';
+import { <%= singular(classify(name)) %>Dto } from './<%= singular(name) %>.dto';
+
+describe('<%= singular(classify(name)) %>Dto', () => {
+  beforeAll(async () => {
+    await getDataSource();
+  });
+
+  describe('constructor', () => {
+    it('converts an entity to a DTO', () => {
+      const <%= singular(camelize(name)) %> = make<%= singular(classify(name)) %>({
+        id: makeDatabaseID(),
+      });
+      const dto = instanceToPlain(new <%= singular(classify(name)) %>Dto(<%= singular(camelize(name)) %>));
+
+      expect(dto).toMatchObject({
+        id: <%= singular(camelize(name)) %>.id,
+        created_at: <%= singular(camelize(name)) %>.createdAt.toISOString(),
+        updated_at: <%= singular(camelize(name)) %>.updatedAt.toISOString(),
+      });
+    });
+  });
+});

--- a/src/lib/api-dtos/files/ts/dto/__name@singular__.dto.ts
+++ b/src/lib/api-dtos/files/ts/dto/__name@singular__.dto.ts
@@ -1,0 +1,17 @@
+<% if (isSwaggerInstalled) { %>import { PartialType } from '@nestjs/swagger';<% } else { %>import { PartialType } from '@nestjs/mapped-types';<% } %>
+import { BaseEntityDto } from '@vori/nest/libs/dto/base-entity.dto';
+import { <%= classify(singular(name)) %> } from '../entities/<%= singular(name) %>.entity';
+
+export class <%= singular(classify(name)) %>Dto extends BaseEntityDto {
+  public constructor(<%= singular(camelize(name)) %>: <%= singular(classify(name)) %>) {
+    super(<%= singular(camelize(name)) %>);
+  }
+}
+
+export class Create<%= singular(classify(name)) %>Dto {
+  public constructor(data?: Partial<Create<%= singular(classify(name)) %>Dto>) {
+    Object.assign(this, data);
+  }
+}
+
+export class Update<%= singular(classify(name)) %>Dto extends PartialType(Create<%= singular(classify(name)) %>Dto) {}

--- a/src/lib/api-dtos/schema.json
+++ b/src/lib/api-dtos/schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "SchematicsNestApiDtos",
+  "title": "Nest API DTOs Options Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the resource.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "The path to create the DTOs.",
+      "visible": false
+    },
+    "sourceRoot": {
+      "type": "string",
+      "description": "Nest DTOs source root."
+    },
+    "language": {
+      "type": "string",
+      "description": "Nest DTOs language."
+    },
+    "spec": {
+      "type": "boolean",
+      "default": true,
+      "description": "Specifies if a spec file is generated."
+    },
+    "specFileSuffix": {
+      "type": "string",
+      "default": "spec",
+      "description": "Specifies the file suffix of spec files."
+    },
+    "flat": {
+      "type": "boolean",
+      "default": false,
+      "description": "Flag to indicate if a directory is created."
+    },
+    "isSwaggerInstalled": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, uses @nestjs/swagger PartialType."
+    }
+  },
+  "required": ["name"]
+}

--- a/src/lib/api-e2e-tests/api-e2e-tests.factory.test.ts
+++ b/src/lib/api-e2e-tests/api-e2e-tests.factory.test.ts
@@ -1,0 +1,96 @@
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { ApiE2eTestsOptions } from './api-e2e-tests.schema';
+
+describe('API E2E Tests Factory', () => {
+  const runner: SchematicTestRunner = new SchematicTestRunner(
+    '.',
+    path.join(process.cwd(), 'src/collection.json'),
+  );
+
+  it('should generate e2e test file', async () => {
+    const options: ApiE2eTestsOptions = {
+      name: 'users',
+      flat: true,
+    };
+    const tree: UnitTestTree = await runner
+      .runSchematicAsync('api-e2e-tests', options)
+      .toPromise();
+    const files: string[] = tree.files;
+
+    expect(
+      files.find((filename) => filename === '/users.e2e.spec.ts'),
+    ).toBeDefined();
+  });
+
+  it('should generate e2e test with correct structure', async () => {
+    const options: ApiE2eTestsOptions = {
+      name: 'users',
+      flat: true,
+    };
+    const tree: UnitTestTree = await runner
+      .runSchematicAsync('api-e2e-tests', options)
+      .toPromise();
+
+    const content = tree.readContent('/users.e2e.spec.ts');
+    expect(content).toContain('describe(\'/v1/users\'');
+    expect(content).toContain('POST /v1/users');
+    expect(content).toContain('GET /v1/users');
+    expect(content).toContain('GET /v1/users/:id');
+    expect(content).toContain('PATCH /v1/users/:id');
+    expect(content).toContain('DELETE /v1/users/:id');
+  });
+
+  it('should handle plural names correctly', async () => {
+    const options: ApiE2eTestsOptions = {
+      name: 'users',
+      flat: true,
+    };
+    const tree: UnitTestTree = await runner
+      .runSchematicAsync('api-e2e-tests', options)
+      .toPromise();
+
+    const content = tree.readContent('/users.e2e.spec.ts');
+    expect(content).toContain('UserDto');
+    expect(content).toContain('CreateUserDto');
+    expect(content).toContain('User ');
+    expect(content).toContain('UsersService');
+  });
+
+  it('should generate e2e test with custom spec suffix', async () => {
+    const options: ApiE2eTestsOptions = {
+      name: 'users',
+      flat: true,
+      specFileSuffix: 'test',
+    };
+    const tree: UnitTestTree = await runner
+      .runSchematicAsync('api-e2e-tests', options)
+      .toPromise();
+    const files: string[] = tree.files;
+
+    expect(
+      files.find((filename) => filename === '/users.e2e.spec.ts'),
+    ).toBeUndefined();
+    expect(
+      files.find((filename) => filename === '/users.e2e.test.ts'),
+    ).toBeDefined();
+  });
+
+  it('should normalize names to kebab-case', async () => {
+    const options: ApiE2eTestsOptions = {
+      name: 'userProfiles',
+      flat: true,
+    };
+    const tree: UnitTestTree = await runner
+      .runSchematicAsync('api-e2e-tests', options)
+      .toPromise();
+    const files: string[] = tree.files;
+
+    expect(
+      files.find((filename) => filename === '/user-profiles.e2e.spec.ts'),
+    ).toBeDefined();
+  });
+});

--- a/src/lib/api-e2e-tests/api-e2e-tests.factory.ts
+++ b/src/lib/api-e2e-tests/api-e2e-tests.factory.ts
@@ -1,0 +1,68 @@
+import { join, Path, strings } from '@angular-devkit/core';
+import { classify } from '@angular-devkit/core/src/utils/strings';
+import {
+  apply,
+  branchAndMerge,
+  chain,
+  mergeWith,
+  move,
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  template,
+  Tree,
+  url,
+} from '@angular-devkit/schematics';
+import * as pluralize from 'pluralize';
+import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
+import { Location, NameParser } from '../../utils/name.parser';
+import { mergeSourceRoot } from '../../utils/source-root.helpers';
+import { ApiE2eTestsOptions } from './api-e2e-tests.schema';
+
+export function main(options: ApiE2eTestsOptions): Rule {
+  options = transform(options);
+  return (tree: Tree, context: SchematicContext) => {
+    return branchAndMerge(
+      chain([mergeSourceRoot(options), mergeWith(generate(options))]),
+    )(tree, context);
+  };
+}
+
+function transform(source: ApiE2eTestsOptions): ApiE2eTestsOptions {
+  const target: ApiE2eTestsOptions = Object.assign({}, source);
+
+  if (!target.name) {
+    throw new SchematicsException('Option (name) is required.');
+  }
+  const location: Location = new NameParser().parse(target);
+  target.name = normalizeToKebabOrSnakeCase(location.name);
+  target.path = normalizeToKebabOrSnakeCase(location.path);
+  target.language = target.language !== undefined ? target.language : 'ts';
+  target.specFileSuffix = normalizeToKebabOrSnakeCase(
+    source.specFileSuffix || 'spec',
+  );
+
+  target.path = target.flat
+    ? target.path
+    : join(target.path as Path, target.name);
+
+  return target;
+}
+
+function generate(options: ApiE2eTestsOptions) {
+  return (context: SchematicContext) =>
+    apply(url(join('./files' as Path, options.language)), [
+      template({
+        ...strings,
+        ...options,
+        lowercased: (name: string) => {
+          const classifiedName = classify(name);
+          return (
+            classifiedName.charAt(0).toLowerCase() + classifiedName.slice(1)
+          );
+        },
+        singular: (name: string) => pluralize.singular(name),
+      }),
+      move(options.path),
+    ])(context);
+}

--- a/src/lib/api-e2e-tests/api-e2e-tests.schema.d.ts
+++ b/src/lib/api-e2e-tests/api-e2e-tests.schema.d.ts
@@ -1,0 +1,29 @@
+import { Path } from '@angular-devkit/core';
+
+export interface ApiE2eTestsOptions {
+  /**
+   * The name of the resource.
+   */
+  name: string;
+  /**
+   * The path to create the e2e tests.
+   */
+  path?: string | Path;
+  /**
+   * The source root path
+   */
+  sourceRoot?: string;
+  /**
+   * Application language.
+   */
+  language?: string;
+  /**
+   * Specifies the file suffix of spec files.
+   * @default "spec"
+   */
+  specFileSuffix?: string;
+  /**
+   * Flag to indicate if a directory is created.
+   */
+  flat?: boolean;
+}

--- a/src/lib/api-e2e-tests/files/ts/__name__.e2e.__specFileSuffix__.ts
+++ b/src/lib/api-e2e-tests/files/ts/__name__.e2e.__specFileSuffix__.ts
@@ -1,0 +1,247 @@
+import { INestApplication } from '@nestjs/common';
+import { instanceToPlain } from 'class-transformer';
+import { orderBy, times } from 'lodash';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import { TransactionalTestContext } from 'typeorm-transactional-tests';
+
+import { Banner } from '@vori/types/Banner';
+import { APIBannerUser } from '@vori/types/User';
+
+import { makeAndSaveBanner } from '@vori/utils/VoriRandom/Banner.random';
+
+import { configureApp } from '@vori/nest/bootstrap';
+import {
+  createAnnotatedUser,
+  createE2ETestingModule,
+  mockTemporalSetupAndShutdown,
+} from '@vori/nest/libs/test_helpers';
+
+// TODO Adjust depending on which service primarily uses the newly-created module.
+import { AppModule } from '../../../../services/graphql-api/src/app.module';
+import {
+  Create<%= singular(classify(name)) %>Dto,
+  <%= singular(classify(name)) %>Dto,
+} from './dto/<%= singular(name) %>.dto';
+import { <%= classify(singular(name)) %> } from './entities/<%= singular(name) %>.entity';
+import { make<%= singular(classify(name)) %>, makeAndSave<%= singular(classify(name)) %> } from './fakers/<%= singular(name) %>.faker';
+import { <%= classify(name) %>Service } from './<%= name %>.service';
+
+describe('/v1/<%= dasherize(name) %>', () => {
+  let app: INestApplication;
+  let db: DataSource;
+  let transactionalContext: TransactionalTestContext;
+  let banner: Banner;
+  let user: APIBannerUser | undefined;
+  let <%= lowercased(name) %>Service: <%= classify(name) %>Service;
+
+  beforeAll(async () => {
+    mockTemporalSetupAndShutdown();
+
+    const moduleRef = await createE2ETestingModule({
+      // TODO Remember to import <%= classify(name) %>Module into AppModule
+      imports: [AppModule],
+    })
+      .mockAuthentication(() => user)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app = configureApp(app);
+    await app.init();
+
+    db = app.get(DataSource);
+    <%= lowercased(name) %>Service = app.get(<%= classify(name) %>Service);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    transactionalContext = new TransactionalTestContext(db);
+    await transactionalContext.start();
+
+    banner = await makeAndSaveBanner(db);
+    user = <APIBannerUser>await createAnnotatedUser({ db, banner });
+  });
+
+  afterEach(async () => {
+    await transactionalContext.finish();
+  });
+
+  describe('POST /v1/<%= dasherize(name) %>', () => {
+    it('requires authorization', async () => {
+      user = undefined;
+      await request(app.getHttpServer())
+        .post('/v1/<%= dasherize(name) %>')
+        .expect(401);
+    });
+
+    it('creates a new <%= singular(classify(name)) %>', async () => {
+      // TODO Add fields
+      const body = new Create<%= singular(classify(name)) %>Dto({});
+
+      const response = await request(app.getHttpServer())
+        .post('/v1/<%= dasherize(name) %>')
+        .send(instanceToPlain(body))
+        .expect(201);
+
+      const <%= singular(camelize(name)) %> = await <%= lowercased(name) %>Service.findOne({
+        bannerID: banner.id,
+        id: response.body.id,
+      });
+      // TODO Assert values stored in database
+
+      expect(response.body).toEqual(
+        instanceToPlain(new <%= singular(classify(name)) %>Dto(<%= singular(camelize(name)) %>))
+      );
+    });
+  });
+
+  describe('GET /v1/<%= dasherize(name) %>', () => {
+    // TODO Modify if the entity is not attached to a banner
+    it('returns all <%= singular(classify(name)) %>s for the authenticated banner', async () => {
+      // No data exists, so nothing returned
+      let response = await request(app.getHttpServer())
+        .get('/v1/<%= dasherize(name) %>')
+        .expect(200);
+      expect(response.body).toEqual([]);
+
+      // Data belonging to other banners should never be returned
+      const otherBanner = await makeAndSaveBanner(db);
+      await makeAndSave<%= singular(classify(name)) %>(db, { banner: otherBanner });
+      response = await request(app.getHttpServer())
+        .get('/v1/<%= dasherize(name) %>')
+        .expect(200);
+      expect(response.body).toEqual([]);
+
+      // Response should include data belonging to this banner
+      const <%= camelize(name) %> = await Promise.all(
+        times(3, async () => makeAndSave<%= singular(classify(name)) %>(db, { banner }))
+      );
+      response = await request(app.getHttpServer())
+        .get('/v1/<%= dasherize(name) %>')
+        .expect(200);
+      expect(response.body).toEqual(
+        orderBy(<%= camelize(name) %>, 'createdAt', 'desc').map(
+          <%= singular(camelize(name)) %> => instanceToPlain(new <%= singular(classify(name)) %>Dto(<%= singular(camelize(name)) %>))
+        )
+      );
+    });
+  });
+
+  describe('GET /v1/<%= dasherize(name) %>/:id', () => {
+    // TODO Update if data is not associated with a banner
+    it('does NOT return data belonging to other banners', async () => {
+      const otherBanner = await makeAndSaveBanner(db);
+      const other<%= singular(classify(name)) %> = await makeAndSave<%= singular(classify(name)) %>(
+        db,
+        { banner: otherBanner }
+      );
+
+      await request(app.getHttpServer())
+        .get(`/v1/<%= dasherize(name) %>/${other<%= singular(classify(name)) %>.id}`)
+        .expect(404);
+    });
+
+    it('returns the <%= singular(classify(name)) %>', async () => {
+      const <%= singular(camelize(name)) %> = await makeAndSave<%= singular(classify(name)) %>(db, {
+        banner,
+      });
+
+      const response = await request(app.getHttpServer())
+        .get(`/v1/<%= dasherize(name) %>/${<%= singular(camelize(name)) %>.id}`)
+        .expect(200);
+
+      expect(response.body).toEqual(
+        instanceToPlain(new <%= singular(classify(name)) %>Dto(<%= singular(camelize(name)) %>))
+      );
+    });
+  });
+
+  describe('PATCH /v1/<%= dasherize(name) %>/:id', () => {
+    // TODO Update if data is not associated with a banner
+    it('does NOT permit modifying data belonging to other banners', async () => {
+      const otherBanner = await makeAndSaveBanner(db);
+      const other<%= singular(classify(name)) %> = await makeAndSave<%= singular(classify(name)) %>(
+        db,
+        { banner: otherBanner }
+      );
+
+      await request(app.getHttpServer())
+        .patch(`/v1/<%= dasherize(name) %>/${other<%= singular(classify(name)) %>.id}`)
+        .send({
+          // TODO Add a body
+        })
+        .expect(404);
+
+      const reloaded<%= singular(classify(name)) %> = await db
+        .getRepository(<%= singular(classify(name)) %>)
+        .findOneOrFail({ where: { id: other<%= singular(classify(name)) %>.id } });
+      expect(reloaded<%= singular(classify(name)) %>.updatedAt).toEqual(
+        other<%= singular(classify(name)) %>.updatedAt
+      );
+      // TODO Assert fields are unchanged
+    });
+
+    it('updates the <%= singular(classify(name)) %>', async () => {
+      const <%= singular(camelize(name)) %> = await makeAndSave<%= singular(classify(name)) %>(db, {
+        banner,
+      });
+
+      // TODO Add a body
+      const body = {};
+      const response = await request(app.getHttpServer())
+        .patch(`/v1/<%= dasherize(name) %>/${<%= singular(camelize(name)) %>.id}`)
+        .send(body)
+        .expect(200);
+
+      const reloaded<%= singular(classify(name)) %> = await db
+        .getRepository(<%= singular(classify(name)) %>)
+        .findOneOrFail({ where: { id: <%= singular(camelize(name)) %>.id } });
+
+      // TODO Assert database fields updated
+
+      expect(response.body).toEqual(
+        instanceToPlain(
+          new <%= singular(classify(name)) %>Dto(reloaded<%= singular(classify(name)) %>)
+        )
+      );
+    });
+  });
+
+  describe('DELETE /v1/<%= dasherize(name) %>/:id', () => {
+    // TODO Update if data is not associated with a banner
+    it('does NOT permit modifying data belonging to other banners', async () => {
+      const otherBanner = await makeAndSaveBanner(db);
+      const other<%= singular(classify(name)) %> = await makeAndSave<%= singular(classify(name)) %>(
+        db,
+        { banner: otherBanner }
+      );
+
+      await request(app.getHttpServer())
+        .delete(`/v1/<%= dasherize(name) %>/${other<%= singular(classify(name)) %>.id}`)
+        .expect(404);
+
+      await db
+        .getRepository(<%= singular(classify(name)) %>)
+        .findOneOrFail({ where: { id: other<%= singular(classify(name)) %>.id } });
+    });
+
+    it('deletes the <%= singular(classify(name)) %>', async () => {
+      const <%= singular(camelize(name)) %> = await makeAndSave<%= singular(classify(name)) %>(db, {
+        banner,
+      });
+
+      await request(app.getHttpServer())
+        .delete(`/v1/<%= dasherize(name) %>/${<%= singular(camelize(name)) %>.id}`)
+        .expect(200);
+
+      expect(
+        await db
+          .getRepository(<%= singular(classify(name)) %>)
+          .exists({ where: { id: <%= singular(camelize(name)) %>.id } })
+      ).toEqual(false);
+    });
+  });
+});

--- a/src/lib/api-e2e-tests/schema.json
+++ b/src/lib/api-e2e-tests/schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "SchematicsNestApiE2eTests",
+  "title": "Nest API E2E Tests Options Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the resource.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "The path to create the e2e tests.",
+      "visible": false
+    },
+    "sourceRoot": {
+      "type": "string",
+      "description": "Nest e2e tests source root."
+    },
+    "language": {
+      "type": "string",
+      "description": "Nest e2e tests language."
+    },
+    "specFileSuffix": {
+      "type": "string",
+      "default": "spec",
+      "description": "Specifies the file suffix of spec files."
+    },
+    "flat": {
+      "type": "boolean",
+      "default": false,
+      "description": "Flag to indicate if a directory is created."
+    }
+  },
+  "required": ["name"]
+}

--- a/src/lib/api-service/api-service.factory.test.ts
+++ b/src/lib/api-service/api-service.factory.test.ts
@@ -1,0 +1,153 @@
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { ApiServiceOptions } from './api-service.schema';
+
+describe('API Service Factory', () => {
+  const runner: SchematicTestRunner = new SchematicTestRunner(
+    '.',
+    path.join(process.cwd(), 'src/collection.json'),
+  );
+
+  describe('with CRUD enabled', () => {
+    it('should generate service with CRUD methods', async () => {
+      const options: ApiServiceOptions = {
+        name: 'users',
+        skipImport: true,
+        flat: true,
+        crud: true,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-service', options)
+        .toPromise();
+      const files: string[] = tree.files;
+
+      expect(
+        files.find((filename) => filename === '/users.service.ts'),
+      ).toBeDefined();
+
+      const content = tree.readContent('/users.service.ts');
+      expect(content).toContain('public async create');
+      expect(content).toContain('public async findAll');
+      expect(content).toContain('public async findOne');
+      expect(content).toContain('public async update');
+      expect(content).toContain('public async remove');
+      expect(content).toContain('private dtoToModel');
+    });
+
+    it('should generate spec file with CRUD enabled', async () => {
+      const options: ApiServiceOptions = {
+        name: 'users',
+        skipImport: true,
+        flat: true,
+        crud: true,
+        spec: true,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-service', options)
+        .toPromise();
+      const files: string[] = tree.files;
+
+      expect(
+        files.find((filename) => filename === '/users.service.spec.ts'),
+      ).toBeDefined();
+    });
+  });
+
+  describe('with CRUD disabled', () => {
+    it('should generate service without CRUD methods', async () => {
+      const options: ApiServiceOptions = {
+        name: 'users',
+        skipImport: true,
+        flat: true,
+        crud: false,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-service', options)
+        .toPromise();
+
+      const content = tree.readContent('/users.service.ts');
+      expect(content).not.toContain('public async create');
+      expect(content).not.toContain('public async findAll');
+      expect(content).not.toContain('private dtoToModel');
+    });
+  });
+
+  describe('spec file generation', () => {
+    it('should not generate spec file when spec is false', async () => {
+      const options: ApiServiceOptions = {
+        name: 'users',
+        skipImport: true,
+        flat: true,
+        spec: false,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-service', options)
+        .toPromise();
+      const files: string[] = tree.files;
+
+      expect(
+        files.find((filename) => filename === '/users.service.spec.ts'),
+      ).toBeUndefined();
+    });
+
+    it('should generate spec file with custom suffix', async () => {
+      const options: ApiServiceOptions = {
+        name: 'users',
+        skipImport: true,
+        flat: true,
+        spec: true,
+        specFileSuffix: 'test',
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-service', options)
+        .toPromise();
+      const files: string[] = tree.files;
+
+      expect(
+        files.find((filename) => filename === '/users.service.spec.ts'),
+      ).toBeUndefined();
+      expect(
+        files.find((filename) => filename === '/users.service.test.ts'),
+      ).toBeDefined();
+    });
+  });
+
+  describe('naming', () => {
+    it('should handle plural names correctly', async () => {
+      const options: ApiServiceOptions = {
+        name: 'users',
+        skipImport: true,
+        flat: true,
+        crud: true,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-service', options)
+        .toPromise();
+
+      const content = tree.readContent('/users.service.ts');
+      expect(content).toContain('export class UsersService');
+      expect(content).toContain('import { User } from');
+      expect(content).toContain('CreateUserDto');
+      expect(content).toContain('UpdateUserDto');
+    });
+
+    it('should normalize names to kebab-case', async () => {
+      const options: ApiServiceOptions = {
+        name: 'userProfiles',
+        skipImport: true,
+        flat: true,
+      };
+      const tree: UnitTestTree = await runner
+        .runSchematicAsync('api-service', options)
+        .toPromise();
+      const files: string[] = tree.files;
+
+      expect(
+        files.find((filename) => filename === '/user-profiles.service.ts'),
+      ).toBeDefined();
+    });
+  });
+});

--- a/src/lib/api-service/api-service.factory.ts
+++ b/src/lib/api-service/api-service.factory.ts
@@ -1,0 +1,110 @@
+import { join, Path, strings } from '@angular-devkit/core';
+import { classify } from '@angular-devkit/core/src/utils/strings';
+import {
+  apply,
+  branchAndMerge,
+  chain,
+  filter,
+  mergeWith,
+  move,
+  noop,
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  template,
+  Tree,
+  url,
+} from '@angular-devkit/schematics';
+import * as pluralize from 'pluralize';
+import { normalizeToKebabOrSnakeCase } from '../../utils/formatting';
+import {
+  DeclarationOptions,
+  ModuleDeclarator,
+} from '../../utils/module.declarator';
+import { ModuleFinder } from '../../utils/module.finder';
+import { Location, NameParser } from '../../utils/name.parser';
+import { mergeSourceRoot } from '../../utils/source-root.helpers';
+import { ApiServiceOptions } from './api-service.schema';
+
+export function main(options: ApiServiceOptions): Rule {
+  options = transform(options);
+  return (tree: Tree, context: SchematicContext) => {
+    return branchAndMerge(
+      chain([
+        mergeSourceRoot(options),
+        addDeclarationToModule(options),
+        mergeWith(generate(options)),
+      ]),
+    )(tree, context);
+  };
+}
+
+function transform(source: ApiServiceOptions): ApiServiceOptions {
+  const target: ApiServiceOptions = Object.assign({}, source);
+  target.metadata = 'providers';
+
+  if (!target.name) {
+    throw new SchematicsException('Option (name) is required.');
+  }
+  const location: Location = new NameParser().parse(target);
+  target.name = normalizeToKebabOrSnakeCase(location.name);
+  target.path = normalizeToKebabOrSnakeCase(location.path);
+  target.language = target.language !== undefined ? target.language : 'ts';
+  target.specFileSuffix = normalizeToKebabOrSnakeCase(
+    source.specFileSuffix || 'spec',
+  );
+
+  target.path = target.flat
+    ? target.path
+    : join(target.path as Path, target.name);
+  return target;
+}
+
+function generate(options: ApiServiceOptions) {
+  return (context: SchematicContext) =>
+    apply(url(join('./files' as Path, options.language)), [
+      options.spec
+        ? noop()
+        : filter((path) => {
+            const suffix = `.__specFileSuffix__.ts`;
+            return !path.endsWith(suffix);
+          }),
+      template({
+        ...strings,
+        ...options,
+        lowercased: (name: string) => {
+          const classifiedName = classify(name);
+          return (
+            classifiedName.charAt(0).toLowerCase() + classifiedName.slice(1)
+          );
+        },
+        singular: (name: string) => pluralize.singular(name),
+      }),
+      move(options.path),
+    ])(context);
+}
+
+function addDeclarationToModule(options: ApiServiceOptions): Rule {
+  return (tree: Tree) => {
+    if (options.skipImport !== undefined && options.skipImport) {
+      return tree;
+    }
+    options.module = new ModuleFinder(tree).find({
+      name: options.name,
+      path: options.path as Path,
+    });
+    if (!options.module) {
+      return tree;
+    }
+    const content = tree.read(options.module).toString();
+    const declarator: ModuleDeclarator = new ModuleDeclarator();
+    tree.overwrite(
+      options.module,
+      declarator.declare(content, {
+        ...options,
+        type: 'service',
+      } as DeclarationOptions),
+    );
+    return tree;
+  };
+}

--- a/src/lib/api-service/api-service.schema.d.ts
+++ b/src/lib/api-service/api-service.schema.d.ts
@@ -1,0 +1,49 @@
+import { Path } from '@angular-devkit/core';
+
+export interface ApiServiceOptions {
+  /**
+   * The name of the service.
+   */
+  name: string;
+  /**
+   * The path to create the service.
+   */
+  path?: string | Path;
+  /**
+   * The source root path
+   */
+  sourceRoot?: string;
+  /**
+   * Application language.
+   */
+  language?: string;
+  /**
+   * Specifies if spec files are generated.
+   */
+  spec?: boolean;
+  /**
+   * Specifies the file suffix of spec files.
+   * @default "spec"
+   */
+  specFileSuffix?: string;
+  /**
+   * The path to insert the module declaration.
+   */
+  module?: Path;
+  /**
+   * Directive to insert declaration in module.
+   */
+  skipImport?: boolean;
+  /**
+   * Metadata name affected by declaration insertion.
+   */
+  metadata?: string;
+  /**
+   * When true, CRUD entry points are generated.
+   */
+  crud?: boolean;
+  /**
+   * Flag to indicate if a directory is created.
+   */
+  flat?: boolean;
+}

--- a/src/lib/api-service/files/ts/__name__.service.__specFileSuffix__.ts
+++ b/src/lib/api-service/files/ts/__name__.service.__specFileSuffix__.ts
@@ -1,0 +1,43 @@
+import { TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { TransactionalTestContext } from 'typeorm-transactional-tests';
+import { createTestingModule } from '@vori/nest/libs/test_helpers';
+import { <%= classify(name) %>Service } from './<%= name %>.service';
+import { <%= classify(singular(name)) %> } from './entities/<%= singular(name) %>.entity';
+
+describe('<%= classify(name) %>Service', () => {
+  let module: TestingModule;
+  let db: DataSource;
+  let transactionalContext: TransactionalTestContext;
+  let service: <%= classify(name) %>Service;
+
+  beforeEach(async () => {
+    module = await createTestingModule({
+      imports: [
+        TypeOrmModule.forFeature([<%= classify(singular(name)) %>]),
+      ],
+      providers: [<%= classify(name) %>Service],
+    }).compile();
+
+    await module.init();
+
+    db = module.get(DataSource);
+    service = module.get(<%= classify(name) %>Service);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    transactionalContext = new TransactionalTestContext(db);
+    await transactionalContext.start();
+  });
+
+  afterEach(async () => {
+    await transactionalContext.finish();
+  });
+
+  // TODO Add relevant tests with database operations
+});

--- a/src/lib/api-service/files/ts/__name__.service.ts
+++ b/src/lib/api-service/files/ts/__name__.service.ts
@@ -1,0 +1,66 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';<% if (crud) { %>
+import { Create<%= singular(classify(name)) %>Dto, Update<%= singular(classify(name)) %>Dto } from './dto/<%= singular(name) %>.dto';<% } %>
+import { <%= classify(singular(name)) %> } from './entities/<%= singular(name) %>.entity';
+
+@Injectable()
+export class <%= classify(name) %>Service {
+  private readonly logger = new Logger(<%= classify(name) %>Service.name);
+
+  constructor(
+    @InjectRepository(<%= classify(singular(name)) %>)
+    private readonly <%= camelize(name) %>Repository: Repository<<%= classify(singular(name)) %>>
+  ) {}
+<% if (crud) { %>
+  public async create({bannerID, dto}: {bannerID: string, dto: Create<%= singular(classify(name)) %>Dto}): Promise<<%= classify(singular(name)) %>> {
+    const <%= singular(camelize(name)) %> = this.dtoToModel(dto);
+
+    // TODO Adjust if the data is not associated with a banner
+    // NOTE: Set this only on creation. Banner IDs are not allowed to change.
+      <%= singular(camelize(name)) %>.bannerID = bannerID;
+
+    return this.<%= camelize(name) %>Repository.save(<%= singular(camelize(name)) %>);
+  }
+
+  public async findAll({bannerID}: {bannerID: string}): Promise<<%= classify(singular(name)) %>[]> {
+    // TODO Adjust the query if the data is not associated with a banner
+    return this.<%= camelize(name) %>Repository.find({
+      comment: `controller='<%= classify(name) %>Service',action='findAll'`,
+      where: { bannerID },
+      order: {
+        createdAt: 'DESC',
+      },
+    });
+  }
+
+  public async findOne({bannerID, id}: {bannerID: string; id: string}): Promise<<%= classify(singular(name)) %>> {
+    // TODO Adjust the query if the data is not associated with a banner
+    return this.<%= camelize(name) %>Repository.findOneOrFail({
+      comment: `controller='<%= classify(name) %>Service',action='findOne'`,
+      where: { id: id.toString(), bannerID },
+    });
+  }
+
+  public async update({bannerID, id, dto}: {bannerID: string; id: string; dto: Update<%= singular(classify(name)) %>Dto}): Promise<<%= classify(singular(name)) %>> {
+    const <%= singular(camelize(name)) %> = await this.findOne({bannerID, id});
+    const updates = this.dtoToModel(dto);
+    return this.<%= camelize(name) %>Repository.save(
+      this.<%= camelize(name) %>Repository.merge(<%= singular(camelize(name)) %>, updates)
+    );
+  }
+
+  public async remove({bannerID, id}: {bannerID: string; id: string}): Promise<void> {
+    const <%= singular(camelize(name)) %> = await this.findOne({bannerID, id});
+    await this.<%= camelize(name) %>Repository.remove(<%= singular(camelize(name)) %>);
+  }
+
+  private dtoToModel(
+      dto: Create<%= singular(classify(name)) %>Dto | Update<%= singular(classify(name)) %>Dto
+  ): <%= classify(singular(name)) %> {
+    // TODO Adjust fields as needed
+    return this.<%= camelize(name) %>Repository.create({
+      ...dto,
+    });
+  }
+<% } %>}

--- a/src/lib/api-service/schema.json
+++ b/src/lib/api-service/schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "SchematicsNestApiService",
+  "title": "Nest API Service Options Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the service.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "The path to create the service.",
+      "visible": false
+    },
+    "sourceRoot": {
+      "type": "string",
+      "description": "Nest service source root."
+    },
+    "language": {
+      "type": "string",
+      "description": "Nest service language."
+    },
+    "spec": {
+      "type": "boolean",
+      "default": true,
+      "description": "Specifies if a spec file is generated."
+    },
+    "specFileSuffix": {
+      "type": "string",
+      "default": "spec",
+      "description": "Specifies the file suffix of spec files."
+    },
+    "flat": {
+      "type": "boolean",
+      "default": false,
+      "description": "Flag to indicate if a directory is created."
+    },
+    "skipImport": {
+      "type": "boolean",
+      "default": false,
+      "description": "Flag to skip the module import."
+    },
+    "module": {
+      "type": "string",
+      "description": "The path to insert the service declaration."
+    },
+    "crud": {
+      "type": "boolean",
+      "default": true,
+      "description": "When true, CRUD entry points are generated."
+    }
+  },
+  "required": ["name"]
+}

--- a/src/lib/resource/resource.factory.test.ts
+++ b/src/lib/resource/resource.factory.test.ts
@@ -19,7 +19,7 @@ describe('Resource Factory', () => {
       const tree = await runner
         .runSchematicAsync('resource', options)
         .toPromise();
-      const files = tree.files;
+      const files = tree.files.sort();
       expect(files).toEqual([
         '/users/users.controller.ts',
         '/users/users.e2e.spec.ts',
@@ -30,7 +30,7 @@ describe('Resource Factory', () => {
         '/users/dto/user.dto.ts',
         '/users/entities/user.entity.ts',
         '/users/fakers/user.faker.ts',
-      ]);
+      ].sort());
     });
     it("should keep underscores in resource's path and file name", async () => {
       const options: ResourceOptions = {
@@ -39,7 +39,7 @@ describe('Resource Factory', () => {
       const tree = await runner
         .runSchematicAsync('resource', options)
         .toPromise();
-      const files = tree.files;
+      const files = tree.files.sort();
       expect(files).toEqual([
         '/_users/_users.controller.ts',
         '/_users/_users.e2e.spec.ts',
@@ -50,7 +50,7 @@ describe('Resource Factory', () => {
         '/_users/dto/_user.dto.ts',
         '/_users/entities/_user.entity.ts',
         '/_users/fakers/_user.faker.ts',
-      ]);
+      ].sort());
     });
     describe('when "crud" option is not enabled', () => {
       it('should generate appropriate files (without dtos)', async () => {
@@ -61,14 +61,14 @@ describe('Resource Factory', () => {
         const tree = await runner
           .runSchematicAsync('resource', options)
           .toPromise();
-        const files = tree.files;
+        const files = tree.files.sort();
         expect(files).toEqual([
           '/users/users.controller.ts',
           '/users/users.module.ts',
           '/users/users.service.spec.ts',
           '/users/users.service.ts',
           '/users/fakers/user.faker.ts',
-        ]);
+        ].sort());
       });
     });
     describe('when "spec" option is not enabled', () => {
@@ -81,13 +81,13 @@ describe('Resource Factory', () => {
         const tree = await runner
           .runSchematicAsync('resource', options)
           .toPromise();
-        const files = tree.files;
+        const files = tree.files.sort();
         expect(files).toEqual([
           '/users/users.controller.ts',
           '/users/users.module.ts',
           '/users/users.service.ts',
           '/users/fakers/user.faker.ts',
-        ]);
+        ].sort());
       });
     });
   });


### PR DESCRIPTION
We can now generate the individual components of a resource to account for cases where we may already have a mixture of existing components and simply need a selection of others.
